### PR TITLE
Clearing caches

### DIFF
--- a/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/load/distance/CodeDistanceMeasurerBase.kt
+++ b/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/load/distance/CodeDistanceMeasurerBase.kt
@@ -19,4 +19,6 @@ abstract class CodeDistanceMeasurerBase<T> {
         edge: SubmissionsGraphEdge,
         graph: SubmissionsGraphAlias,
     ) = computeFullDistanceWithCache(edge, graph).calculateWeight()
+
+    open fun clear() = cache.clear()
 }

--- a/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
+++ b/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
@@ -26,7 +26,7 @@ fun <T> DataFrame<*>.loadGraph(context: SubmissionsGraphContext<T>): Submissions
                     Submission(
                         info = SubmissionInfo(getValue(id), getValue(quality)),
                         stepId = getValue(step_id),
-                        code = getValue(code)
+                        code = getValue(code).replace("\r\n", "\n")
                     )
                 )
             }

--- a/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
+++ b/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
@@ -26,7 +26,7 @@ fun <T> DataFrame<*>.loadGraph(context: SubmissionsGraphContext<T>): Submissions
                     Submission(
                         info = SubmissionInfo(getValue(id), getValue(quality)),
                         stepId = getValue(step_id),
-                        code = getValue(code).replace("\r\n", "\n")
+                        code = getValue(code).normalize()
                     )
                 )
             }

--- a/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
+++ b/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/LoadUtil.kt
@@ -32,8 +32,9 @@ fun <T> DataFrame<*>.loadGraph(context: SubmissionsGraphContext<T>): Submissions
             }
             // We don't share it with distances, so we can remove extra information
             context.unifier.clear()
-
             calculateDistances()
+            // Caches might be controlled by external processes, so we should clear them explicitly
+            context.codeDistanceMeasurer.clear()
         }
     }
     return graph

--- a/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/StringUtil.kt
+++ b/code-submissions-clustering-core/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/util/StringUtil.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.research.code.submissions.clustering.util
+
+fun String.normalize() = this.replace("\r\n", "\n").replace("\r", "\n")

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/CodeServerClientImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/CodeServerClientImpl.kt
@@ -35,7 +35,9 @@ class CodeServerClientImpl(private val channel: ManagedChannel) : Closeable {
         return stub.calculateWeight(request).weight
     }
 
-    suspend fun clear() = stub.clear(Empty.newBuilder().build())
+    suspend fun clearUnifier() = stub.clearUnifier(Empty.newBuilder().build())
+
+    suspend fun clearDistMeasurer() = stub.clearDistMeasurer(Empty.newBuilder().build())
 
     private fun submissionsCode(code: String) =
         SubmissionCode

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/CodeServerClientImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/CodeServerClientImpl.kt
@@ -2,6 +2,7 @@ package org.jetbrains.research.code.submissions.clustering.client
 
 import io.grpc.ManagedChannel
 import org.jetbrains.research.code.submissions.clustering.CodeServerGrpcKt
+import org.jetbrains.research.code.submissions.clustering.Empty
 import org.jetbrains.research.code.submissions.clustering.SubmissionCode
 import org.jetbrains.research.code.submissions.clustering.SubmissionsEdge
 import org.jetbrains.research.code.submissions.clustering.model.Submission
@@ -33,6 +34,8 @@ class CodeServerClientImpl(private val channel: ManagedChannel) : Closeable {
         )
         return stub.calculateWeight(request).weight
     }
+
+    suspend fun clear() = stub.clear(Empty.newBuilder().build())
 
     private fun submissionsCode(code: String) =
         SubmissionCode

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjGumTreeDistanceMeasurer.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjGumTreeDistanceMeasurer.kt
@@ -11,4 +11,8 @@ class IjGumTreeDistanceMeasurer(private val clientImpl: CodeServerClientImpl) : 
     override fun computeFullDistance(edge: SubmissionsGraphEdge, graph: SubmissionsGraphAlias): Int = runBlocking {
         clientImpl.calculateDist(edge, graph)
     }
+
+    override fun clear(): Unit = runBlocking {
+        clientImpl.clearDistMeasurer()
+    }
 }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjUnifier.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjUnifier.kt
@@ -8,4 +8,8 @@ class IjUnifier(private val clientImpl: CodeServerClientImpl) : Unifier {
     override fun Submission.unify(): Submission = runBlocking {
         clientImpl.unify(this@unify)
     }
+
+    override fun clear(): Unit = runBlocking {
+        clientImpl.clear()
+    }
 }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjUnifier.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/client/IjUnifier.kt
@@ -10,6 +10,6 @@ class IjUnifier(private val clientImpl: CodeServerClientImpl) : Unifier {
     }
 
     override fun clear(): Unit = runBlocking {
-        clientImpl.clear()
+        clientImpl.clearUnifier()
     }
 }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/impl/unifiers/AbstractUnifier.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/impl/unifiers/AbstractUnifier.kt
@@ -62,7 +62,7 @@ abstract class AbstractUnifier(
     @Suppress("TOO_MANY_LINES_IN_LAMBDA")
     override fun Submission.unify(): Submission {
         val statsBuilder = TransformationsStatisticsBuilder()
-        val code = codeToUnifiedCode.getOrDefault(this.code, this.code.let { code ->
+        val code = this.code.let { code ->
             val psi = psiFileFactory.getPsiFile(code)
             ApplicationManager.getApplication().invokeAndWait {
                 ApplicationManager.getApplication().runWriteAction {
@@ -76,15 +76,15 @@ abstract class AbstractUnifier(
                         psi.applyTransformations(transformations, statsBuilder, previousTree)
                         logger.finer { "Previous text[$iterationNumber]:\n${previousTree.text}\n" }
                         logger.finer { "Current text[$iterationNumber]:\n${psi.text}\n\n" }
-                    } while (!previousTree.textMatches(psi.text) && iterationNumber <= MAX_ITERATIONS && codeToUnifiedCode[psi.text] == null)
+                    } while (!previousTree.textMatches(psi.text) && iterationNumber <= MAX_ITERATIONS)
                     logger.fine { "Tree Ended[[$iterationNumber]]: ${psi.text}\n\n\n" }
                     logger.info { "Total iterations number: $iterationNumber" }
                 }
             }
-            codeToUnifiedCode.getOrPut(psi.text) { psi.reformatInWriteAction().text }.also {
+            psi.reformatInWriteAction().text.also {
                 psiFileFactory.releasePsiFile(psi)
             }
-        })
+        }
         logger.info {
             statsBuilder.buildStatistics(listOfNotNull(anonymization) + transformations)
         }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/impl/unifiers/AbstractUnifier.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/impl/unifiers/AbstractUnifier.kt
@@ -1,6 +1,5 @@
 package org.jetbrains.research.code.submissions.clustering.impl.unifiers
 
-import com.intellij.ide.impl.ProjectUtil
 import com.intellij.openapi.application.ApplicationManager
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
@@ -13,7 +12,6 @@ import org.jetbrains.research.code.submissions.clustering.impl.util.psi.reformat
 import org.jetbrains.research.code.submissions.clustering.load.unifiers.Unifier
 import org.jetbrains.research.code.submissions.clustering.model.Language
 import org.jetbrains.research.code.submissions.clustering.model.Submission
-import org.jetbrains.research.code.submissions.clustering.util.getTmpProjectDir
 import org.jetbrains.research.ml.ast.transformations.Transformation
 import java.util.logging.Logger
 
@@ -27,7 +25,6 @@ abstract class AbstractUnifier(
     private val logger = Logger.getLogger(javaClass.name)
     abstract val language: Language
     abstract val transformations: List<Transformation>
-    private val codeToUnifiedCode = HashMap<String, String>()
     protected abstract val psiFileFactory: PsiFileFactory
 
     @Suppress("TooGenericExceptionCaught")
@@ -91,14 +88,7 @@ abstract class AbstractUnifier(
         return this.copy(code = code)
     }
 
-    fun clearCache() = codeToUnifiedCode.clear()
-
-    override fun clear() = clearCache()
-
     companion object {
         const val MAX_ITERATIONS = 50
     }
 }
-
-fun createTempProject(): Project = ProjectUtil.openOrImport(getTmpProjectDir(), null, true)
-    ?: error("Internal error: the temp project was not created")

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerImpl.kt
@@ -34,7 +34,8 @@ class CodeServerImpl(private val port: Int, language: Language) {
                         responseChannel.send(UnifyResponse(unifyImpl(request.submissionCode)))
                     is CalcDistRequest ->
                         responseChannel.send(CalcDistResponse(calculateWeightImpl(request.submissionsEdge)))
-                    is ClearRequest -> graphContext.unifier.clear()
+                    is ClearUnifierRequest -> graphContext.unifier.clear()
+                    is ClearDistMeasurerRequest -> graphContext.codeDistanceMeasurer.clear()
                 }
             }
         }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerImpl.kt
@@ -29,11 +29,13 @@ class CodeServerImpl(private val port: Int, language: Language) {
         logger.info("Server started, listening on $port")
         runBlocking {
             while (true) {
-                val response = when (val request = requestChannel.receive()) {
-                    is UnifyRequest -> UnifyResponse(unifyImpl(request.submissionCode))
-                    is CalcDistRequest -> CalcDistResponse(calculateWeightImpl(request.submissionsEdge))
+                when (val request = requestChannel.receive()) {
+                    is UnifyRequest ->
+                        responseChannel.send(UnifyResponse(unifyImpl(request.submissionCode)))
+                    is CalcDistRequest ->
+                        responseChannel.send(CalcDistResponse(calculateWeightImpl(request.submissionsEdge)))
+                    is ClearRequest -> graphContext.unifier.clear()
                 }
-                responseChannel.send(response)
             }
         }
     }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerRequest.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerRequest.kt
@@ -14,3 +14,5 @@ data class UnifyRequest(val submissionCode: SubmissionCode) : CodeServerRequest
  * @property submissionsEdge pair of submissions codes
  */
 data class CalcDistRequest(val submissionsEdge: SubmissionsEdge) : CodeServerRequest
+
+object ClearRequest : CodeServerRequest

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerRequest.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerRequest.kt
@@ -15,4 +15,6 @@ data class UnifyRequest(val submissionCode: SubmissionCode) : CodeServerRequest
  */
 data class CalcDistRequest(val submissionsEdge: SubmissionsEdge) : CodeServerRequest
 
-object ClearRequest : CodeServerRequest
+object ClearUnifierRequest : CodeServerRequest
+
+object ClearDistMeasurerRequest : CodeServerRequest

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerServiceImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerServiceImpl.kt
@@ -22,8 +22,15 @@ class CodeServerServiceImpl(
         return (responseChannel.receive() as CalcDistResponse).submissionsWeight
     }
 
-    override suspend fun clear(request: Empty): Empty {
-        requestChannel.send(ClearRequest)
+    override suspend fun clearUnifier(request: Empty): Empty {
+        logger.info("Clear unifier request sent to server")
+        requestChannel.send(ClearUnifierRequest)
+        return Empty.newBuilder().build()
+    }
+
+    override suspend fun clearDistMeasurer(request: Empty): Empty {
+        logger.info("Clear code distance measurer request sent to server")
+        requestChannel.send(ClearDistMeasurerRequest)
         return Empty.newBuilder().build()
     }
 }

--- a/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerServiceImpl.kt
+++ b/code-submissions-clustering-ij/src/main/kotlin/org/jetbrains/research/code/submissions/clustering/server/CodeServerServiceImpl.kt
@@ -1,10 +1,7 @@
 package org.jetbrains.research.code.submissions.clustering.server
 
 import kotlinx.coroutines.channels.Channel
-import org.jetbrains.research.code.submissions.clustering.CodeServerGrpcKt
-import org.jetbrains.research.code.submissions.clustering.SubmissionCode
-import org.jetbrains.research.code.submissions.clustering.SubmissionsEdge
-import org.jetbrains.research.code.submissions.clustering.SubmissionsWeight
+import org.jetbrains.research.code.submissions.clustering.*
 import java.util.logging.Logger
 
 class CodeServerServiceImpl(
@@ -23,5 +20,10 @@ class CodeServerServiceImpl(
         requestChannel.send(CalcDistRequest(request))
         logger.info("Distance calculation request sent to server")
         return (responseChannel.receive() as CalcDistResponse).submissionsWeight
+    }
+
+    override suspend fun clear(request: Empty): Empty {
+        requestChannel.send(ClearRequest)
+        return Empty.newBuilder().build()
     }
 }

--- a/code-submissions-clustering-ij/src/main/proto/CodeServerService.proto
+++ b/code-submissions-clustering-ij/src/main/proto/CodeServerService.proto
@@ -7,7 +7,8 @@ option java_outer_classname = "CodeServerServiceProtos";
 service CodeServer {
   rpc Unify(SubmissionCode) returns (SubmissionCode) {}
   rpc CalculateWeight(SubmissionsEdge) returns (SubmissionsWeight) {}
-  rpc Clear(Empty) returns (Empty) {}
+  rpc ClearUnifier(Empty) returns (Empty) {}
+  rpc ClearDistMeasurer(Empty) returns (Empty) {}
 }
 
 message SubmissionCode {

--- a/code-submissions-clustering-ij/src/main/proto/CodeServerService.proto
+++ b/code-submissions-clustering-ij/src/main/proto/CodeServerService.proto
@@ -7,6 +7,7 @@ option java_outer_classname = "CodeServerServiceProtos";
 service CodeServer {
   rpc Unify(SubmissionCode) returns (SubmissionCode) {}
   rpc CalculateWeight(SubmissionsEdge) returns (SubmissionsWeight) {}
+  rpc Clear(Empty) returns (Empty) {}
 }
 
 message SubmissionCode {
@@ -21,3 +22,5 @@ message SubmissionsEdge {
 message SubmissionsWeight {
   int32 weight = 1;
 }
+
+message Empty {}

--- a/scripts/src/utils/runners/abstract_runner.py
+++ b/scripts/src/utils/runners/abstract_runner.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Tuple, Dict, Any
+from typing import Tuple, Dict, Any, List
 
 from src.utils.run_process_utils import run_in_subprocess
 
@@ -12,7 +12,7 @@ class AbstractRunner(ABC):
 
     @abstractmethod
     def build_arguments(self, *args, **kwargs) \
-            -> Tuple[Dict[Any, Any], Dict[Any, bool]]:
+            -> Tuple[Dict[Any, Any], Dict[Any, bool], List[Any]]:
         """Build arguments for CLI."""
         pass
 
@@ -21,15 +21,16 @@ class AbstractRunner(ABC):
             self,
             named_args: Dict[Any, Any],
             flag_args: Dict[Any, bool],
-    ) -> str:
+            positional_args: List[Any] = None,
+    ) -> List[str]:
         """Build command to execute."""
         pass
 
     def run(self, *args, **kwargs) -> str:
         """Run process and return its stderr."""
-        named_args, flag_args = self.build_arguments(*args, **kwargs)
-        cmd = self.configure_cmd(named_args, flag_args)
-        return_code, stdout, stderr = run_in_subprocess(cmd.split(), self.WORKING_DIR)
+        named_args, flag_args, positional_args = self.build_arguments(*args, **kwargs)
+        cmd = self.configure_cmd(named_args, flag_args, positional_args)
+        return_code, stdout, stderr = run_in_subprocess(cmd, self.WORKING_DIR)
         if return_code != 0:
             return ''
         return stderr

--- a/scripts/src/utils/runners/external_tools_runners/jplag_runner.py
+++ b/scripts/src/utils/runners/external_tools_runners/jplag_runner.py
@@ -152,7 +152,8 @@ class JPlagRunner(AbstractRunner):
             self,
             named_args: Dict[str, Any],
             flag_args: Dict[str, bool],
-    ) -> str:
+            positional_args=None,
+    ) -> List[str]:
         cmd = 'java -jar'
         for arg_name, arg_value in named_args.items():
             if not arg_name.startswith('-'):
@@ -162,7 +163,7 @@ class JPlagRunner(AbstractRunner):
         for arg_name, arg_value in flag_args.items():
             if arg_value:
                 cmd = cmd + f' {arg_name}'
-        return cmd
+        return cmd.split()
 
     def run(
             self,

--- a/scripts/src/utils/runners/gradle_task_runners/calculate_dist_runner.py
+++ b/scripts/src/utils/runners/gradle_task_runners/calculate_dist_runner.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 from src.utils.models.cli_models import TaskFlagArgs, TaskNamedArgs
 from src.utils.models.script_parameters import CalculateDistancesParameters
@@ -16,7 +16,7 @@ class CalculateDistRunner(AbstractTaskRunner):
             step_id: int,
             script_params: CalculateDistancesParameters,
             **kwargs,
-    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool]]:
+    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool], List[TaskNamedArgs]]:
         """Build arguments for 'calculate-dist' CLI."""
         named_args = get_common_named_arguments(
             step_id,
@@ -24,4 +24,4 @@ class CalculateDistRunner(AbstractTaskRunner):
             'build_initial_graph_filename',
             **kwargs,
         )
-        return named_args, TaskFlagArgs.get_all_flags(script_params)
+        return named_args, TaskFlagArgs.get_all_flags(script_params), [TaskNamedArgs.INPUT_FILE]

--- a/scripts/src/utils/runners/gradle_task_runners/clustering_runner.py
+++ b/scripts/src/utils/runners/gradle_task_runners/clustering_runner.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 from src.utils.models.cli_models import TaskFlagArgs, TaskNamedArgs
 from src.utils.models.script_parameters import ClusteringParameters
@@ -16,7 +16,7 @@ class ClusteringRunner(AbstractTaskRunner):
             step_id: int,
             script_params: ClusteringParameters,
             **kwargs,
-    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool]]:
+    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool], List[TaskNamedArgs]]:
         """Build arguments for 'cluster' CLI."""
         named_args = get_common_named_arguments(
             step_id,
@@ -25,4 +25,5 @@ class ClusteringRunner(AbstractTaskRunner):
             **kwargs,
         )
         named_args[TaskNamedArgs.DISTANCE_LIMIT] = script_params.distance_limit
-        return named_args, TaskFlagArgs.get_all_flags(script_params)
+        return named_args, TaskFlagArgs.get_all_flags(script_params), [TaskNamedArgs.INPUT_FILE,
+                                                                       TaskNamedArgs.DISTANCE_LIMIT]

--- a/scripts/src/utils/runners/gradle_task_runners/load_runner.py
+++ b/scripts/src/utils/runners/gradle_task_runners/load_runner.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, Tuple
+from typing import Any, Dict, Tuple, List
 
 from src.utils.models.cli_models import TaskFlagArgs, TaskNamedArgs
 from src.utils.models.script_parameters import LoadSubmissionsGraphParameters
@@ -16,7 +16,7 @@ class LoadRunner(AbstractTaskRunner):
             step_id: int,
             script_params: LoadSubmissionsGraphParameters,
             **kwargs,
-    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool]]:
+    ) -> Tuple[Dict[TaskNamedArgs, Any], Dict[TaskFlagArgs, bool], List[TaskNamedArgs]]:
         """Build arguments for 'load' CLI."""
         named_args = get_common_named_arguments(
             step_id,
@@ -24,4 +24,4 @@ class LoadRunner(AbstractTaskRunner):
             'build_solutions_file_name',
             **kwargs,
         )
-        return named_args, TaskFlagArgs.get_all_flags(script_params)
+        return named_args, TaskFlagArgs.get_all_flags(script_params), [TaskNamedArgs.INPUT_FILE]


### PR DESCRIPTION
Removed caching in the unifier on the server side and added caching when building a graph to minimize calls to the unifier. Also added the ability to clear code measure distancer caches and necessary methods for ij server.